### PR TITLE
IntOrString.toJson implemented.

### DIFF
--- a/lib/src/int_or_string.dart
+++ b/lib/src/int_or_string.dart
@@ -16,4 +16,6 @@ class IntOrString {
   String toString() {
     return value.toString();
   }
+  
+  Object toJson() => value;
 }


### PR DESCRIPTION
Currently while serializing IntOrString class to json encoder throws. This little addition should fix the issue.